### PR TITLE
php 7 fixes

### DIFF
--- a/jsmin.c
+++ b/jsmin.c
@@ -88,9 +88,6 @@ jsmin_get(jsmin_obj *jmo)
 	if (c == '\r') {
 		return '\n';
 	}
-	if (isutf(c)) {
-		return c;
-	}
 	return ' ';
 }
 

--- a/php_jsmin.c
+++ b/php_jsmin.c
@@ -100,7 +100,7 @@ ZEND_GET_MODULE(jsmin)
 PHP_FUNCTION(jsmin)
 {
 	char *javascript;
-	int javascript_len;
+	size_t javascript_len;
 	jsmin_obj *jmo;
 
 	zval *ret_code = NULL;


### PR DESCRIPTION
I was able to track down the source of the segfault for php7. With this patch, `make test` passes all tests and I no longer get a segfault.

The issue was with a change to zend_parse_parameters() specs. In php5, the s spec accepted int types, but in php7, that was dropped in favor of size_t.