### PR TITLE
Revert to pre-UTF-8 behavior of dropping most control characters

### DIFF
--- a/jsmin.c
+++ b/jsmin.c
@@ -88,9 +88,6 @@ jsmin_get(jsmin_obj *jmo)
 	if (c == '\r') {
 		return '\n';
 	}
-	if (isutf(c)) {
-		return c;
-	}
 	return ' ';
 }
 


### PR DESCRIPTION
The UTF-8 code led to tabs and other control characters no longer being stripped. This fixes that so that tabs are stripped again.