### PR TITLE
Issue #51: feature/php7 now compiles under FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ http://www.crockford.com/javascript/jsmin.html
 
 This extension currently works with PHP 5.3.10+. Support for older versions of PHP is not provided.
 
+The feature/php7 branch has been updated to compile successfully on FreeBSD under PHP 7, see [Rafal Lukawiecki's fork.](https://github.com/RafalLukawiecki/pecl-jsmin), which resolves [Issue #51](https://github.com/sqmk/pecl-jsmin/issues/51).
+
 ## Installation
 
 ### Via PECL

--- a/utf8.c
+++ b/utf8.c
@@ -19,7 +19,9 @@
 #ifdef WIN32
 #include <malloc.h>
 #else
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
Simple change to avoid including a non-existent (and unnecessary) library under FreeBSD. I have only updated the feature/php7 branch.