### PR TITLE
Improve tests for PHP 8

### DIFF
--- a/jsmin.c
+++ b/jsmin.c
@@ -34,7 +34,7 @@ SOFTWARE.
 */
 
 static jsmin_obj*
-new_jsmin_obj(char *javascript TSRMLS_DC)
+new_jsmin_obj(char *javascript)
 {
 	jsmin_obj *jmo	= ecalloc(1, sizeof(jsmin_obj));
 	jmo->javascript = javascript;
@@ -48,7 +48,7 @@ new_jsmin_obj(char *javascript TSRMLS_DC)
 /* free_jsmin_obj -- frees up memory on struct
 */
 void
-free_jsmin_obj(jsmin_obj *jmo TSRMLS_DC)
+free_jsmin_obj(jsmin_obj *jmo)
 {
 	smart_string_free(&jmo->buffer);
 	efree(jmo);
@@ -250,9 +250,9 @@ jsmin_action(int d, jsmin_obj *jmo)
 */
 
 jsmin_obj*
-jsmin(char *javascript TSRMLS_DC)
+jsmin(char *javascript)
 {
-	jsmin_obj *jmo = new_jsmin_obj(javascript TSRMLS_CC);
+	jsmin_obj *jmo = new_jsmin_obj(javascript);
 
 	jsmin_action(3, jmo);
 	while (jmo->theA != 0) {

--- a/jsmin.h
+++ b/jsmin.h
@@ -25,7 +25,7 @@ enum error_codes {
   PHP_JSMIN_ERROR_UNTERMINATED_REGEX
 };
 
-extern jsmin_obj* jsmin(char *javascript TSRMLS_DC);
-extern void free_jsmin_obj(jsmin_obj *jmo TSRMLS_DC);
+extern jsmin_obj* jsmin(char *javascript);
+extern void free_jsmin_obj(jsmin_obj *jmo);
 
 #endif

--- a/php_jsmin.c
+++ b/php_jsmin.c
@@ -105,11 +105,11 @@ PHP_FUNCTION(jsmin)
 
 	zval *ret_code = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|z/", &javascript, &javascript_len, &ret_code) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|z/", &javascript, &javascript_len, &ret_code) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	jmo = jsmin(javascript TSRMLS_CC);
+	jmo = jsmin(javascript);
 	if (ret_code) {
 		zval_dtor(ret_code);
 		ZVAL_LONG(ret_code, jmo->errorCode);
@@ -121,7 +121,7 @@ PHP_FUNCTION(jsmin)
 	} else {
 		ZVAL_STRINGL(return_value, jmo->buffer.c, jmo->buffer.len);
 	}
-	free_jsmin_obj(jmo TSRMLS_CC);
+	free_jsmin_obj(jmo);
 }
 /* }}} */
 

--- a/tests/99-compress-jquery.phpt
+++ b/tests/99-compress-jquery.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Test jsmin with jquery
+--SKIPIF--
+<?php
+if (!file_exists(__DIR__ . '/data/jquery-2.1.3.js')) die('skip no jquery found');
+?>
 --FILE--
 <?php
 $js = file_get_contents(__DIR__ . '/data/jquery-2.1.3.js');

--- a/tests/missing-argument.phpt
+++ b/tests/missing-argument.phpt
@@ -1,5 +1,9 @@
 --TEST--
 Missing argument throws warning
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80000) die('skip Only for PHP < 8.0');
+?>
 --FILE--
 <?php
 

--- a/tests/missing-argument8.phpt
+++ b/tests/missing-argument8.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Missing argument throws fatal error
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000) die('skip Only for PHP >= 8.0');
+?>
+--FILE--
+<?php
+
+echo jsmin();
+
+--EXPECTF--
+Fatal error: Uncaught ArgumentCountError: jsmin() expects at least 1 argument, 0 given in %s
+Stack trace:
+#0 %s(3): jsmin()
+#1 {main}
+  thrown in %s on line 3


### PR DESCRIPTION
based on https://github.com/sqmk/pecl-jsmin/pull/59

- `tests/99-compress-jquery.phpt` fails because package from PECL has no jquery shipped, and that's valid as the commited version is outdated
- `tests/missing-argument8.phpt` is a copy for PHP 8+ as missing argument is required (throws fatal)

It should also cover current PHP 8.1 beta3 https://github.com/sqmk/pecl-jsmin/issues/58